### PR TITLE
enh(client) channel subscriptions status and other updates

### DIFF
--- a/core/exchange_interface.py
+++ b/core/exchange_interface.py
@@ -316,6 +316,18 @@ class ExchangeInterface:
             check if balance is sufficient for order
 
         """
+        if symbol not in self.ws.symbols:
+            logging.error(
+                f"Cannot place an order for symbol {symbol}. You need to subscribe to the symbol first"
+            )
+            return
+        if symbol not in self.ws.symbol_details:
+            logging.warning(
+                f"Could not find symbol details for {symbol}. Make sure the symbol was successfully "
+                f"subscribed to."
+            )
+            return
+
         order = self._create_order(
             symbol,
             side,
@@ -382,7 +394,7 @@ class ExchangeInterface:
         last_traded_price : float
             last matched price for symbol
         """
-        return self.ws.tickers.get(symbol)
+        return self.ws.tickers.get(symbol, {}).get("last_traded_price")
 
     def get_ask_price(self, symbol):
         """Get the ask price for the given symbol
@@ -483,8 +495,11 @@ class ExchangeInterface:
         """Get all the symbols"""
         return self.ws.symbols
 
+
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)
-    exchange = ExchangeInterface(["BTC-USD"], channels=[Channel.TICKER])
+    exchange = ExchangeInterface(["BTC-USD", "ETH-USD"])
 
     exchange.connect()
+    while True:
+        pass

--- a/core/utils.py
+++ b/core/utils.py
@@ -23,3 +23,9 @@ def valid_datetime(s):
     """
 
     return iso8601.parse_date(s)
+
+
+def update_max_list(l, e, n):
+    """Update a list and enforce maximum length"""
+    l.append(e)
+    return l[-n:]

--- a/core/websocket_client.py
+++ b/core/websocket_client.py
@@ -100,7 +100,7 @@ class ChannelStatus:
 
 
 class BcexClient(object):
-    """Blockchain Exchange Websocket API client v1
+    """Blockchain.com Exchange Websocket API client v1
 
     Attributes
     ----------
@@ -219,6 +219,8 @@ class BcexClient(object):
                 self.channel_kwargs[ch].update(channel_kwargs)
 
     def _init_channel_status(self):
+        """Initialise or reset channel status
+        """
         self.channel_status = {}
         # channels symbols specific
         for channel in set(self.channels).intersection(set(Channel.PUBLIC)):
@@ -373,6 +375,8 @@ class BcexClient(object):
         logging.warning("\n-- Websocket Closed --")
 
     def on_error(self, error):
+        """On error websocket connection
+        """
         self._on_error(error)
 
     def _on_error(self, err):
@@ -381,10 +385,13 @@ class BcexClient(object):
         self.exit()
 
     def exit(self):
+        """On exit websocket connection
+        """
         if self.cancel_position_on_exit and self.authenticated:
             self.cancel_all_orders()
         self.ws.close()
         self.exited = True
+        self._init_channel_status()
 
     def on_message(self, msg):
         """Parses the message returned from the websocket depending on which channel returns it

--- a/core/websocket_client.py
+++ b/core/websocket_client.py
@@ -9,7 +9,7 @@ import websocket as webs
 from core.order_response import OrderResponse, OrderStatus
 from core.orders import Order, OrderType
 from core.trade import Trade
-from core.utils import parse_balance, valid_datetime
+from core.utils import parse_balance, update_max_list, valid_datetime
 from sortedcontainers import SortedDict as sd
 
 MESSAGE_LIMIT = 1200  # number of messages per minute allowed
@@ -52,6 +52,29 @@ class Channel:
     PUBLIC = [HEARTBEAT, TICKER, PRICES, TRADES, L2, L3, SYMBOLS]
     PRIVATE = [AUTH, BALANCES, TRADING]
 
+    @staticmethod
+    def is_symbol_specific(channel):
+        """Whether the channel is symbol specific
+        """
+        if channel in [
+            Channel.AUTH,
+            Channel.HEARTBEAT,
+            Channel.TRADING,
+            Channel.BALANCES,
+        ]:
+            return False
+        elif channel in [
+            Channel.L2,
+            Channel.L3,
+            Channel.PRICES,
+            Channel.SYMBOLS,
+            Channel.TICKER,
+            Channel.TRADES,
+        ]:
+            return True
+        else:
+            raise ValueError(f"Unexpected channel {channel}")
+
 
 class Event:
     """Indicate the purpose of the message
@@ -66,10 +89,14 @@ class Event:
     ALL = [UPDATED, SNAPSHOT, REJECTED, SUBSCRIBED, UNSUBSCRIBED]
 
 
-def _update_max_list(l, e, n):
-    """Update a list and enforce maximum length"""
-    l.append(e)
-    return l[-n:]
+class ChannelStatus:
+    """Indicates the status of the channels subscriptions
+    """
+
+    SUBSCRIBED = "subscribed"
+    UNSUBSCRIBED = "unsubscribed"
+    WAITING_CONFIRMATION = "waiting_confirmation"
+    REJECTED = "rejected"
 
 
 class BcexClient(object):
@@ -79,6 +106,12 @@ class BcexClient(object):
     ----------
     balances : dict
     open_orders : dict
+    channel_status: dict
+        keeps track of the status of each subscription using ChannelStatus
+        keys are channels, str from the enum Channel.
+         - for symbol specific channels, the value is a dict with key the symbol, str from the enum Symbol
+            and value the status, str from the enum ChannelStatus
+         - for non-symbol specific channels, the value is the status, str from the enum ChannelStatus
 
     Notes
     -----
@@ -93,7 +126,7 @@ class BcexClient(object):
         symbols,
         channels=None,
         channel_kwargs=None,
-        env=Environment.STAGING,
+        env=Environment.PROD,
         api_secret=None,
         cancel_position_on_exit=True,
     ):
@@ -133,20 +166,21 @@ class BcexClient(object):
 
         self.cancel_position_on_exit = cancel_position_on_exit
         self._error = None
-        self.authenticated = False
         self.ws_url = ws_url
         self.origin = origin_url
         self.exited = False
 
         self.symbols = symbols
         self.symbol_details = {s: {} for s in symbols}
+
         self.channels = channels or list(
             set(Channel.ALL) - {Channel.L3}
         )  # L3 not handled yet
-
         # default channel_kwargs
         self.channel_kwargs = {Channel.PRICES: {"granularity": 60}}
         self._update_default_channel_kwargs(channel_kwargs)
+
+        self.channel_status = None
 
         # webs.enableTrace(True)
         self.ws = None
@@ -159,7 +193,7 @@ class BcexClient(object):
 
         # use these dictionaries to store the data we receive
         self.balances = {}
-        self.tickers = {}
+        self.tickers = defaultdict(dict)
 
         self.l2_book = {}
         for symbol in self.symbols:
@@ -173,6 +207,9 @@ class BcexClient(object):
         self._seqnum = -1  # higher seqnum that we received (usually the latest)
         self._last_heartbeat = None
 
+        # set initial status to unsubcribed
+        self._init_channel_status()
+
     def _update_default_channel_kwargs(self, channel_kwargs):
         # override channel_kwargs with specified channel_kwargs
         if channel_kwargs is not None:
@@ -180,6 +217,18 @@ class BcexClient(object):
                 if ch not in self.channel_kwargs:
                     self.channel_kwargs[ch] = {}
                 self.channel_kwargs[ch].update(channel_kwargs)
+
+    def _init_channel_status(self):
+        self.channel_status = {}
+        # channels symbols specific
+        for channel in set(self.channels).intersection(set(Channel.PUBLIC)):
+            self.channel_status[channel] = {
+                s: ChannelStatus.UNSUBSCRIBED for s in self.symbols
+            }
+
+        # channels non symbols specific
+        for channel in set(self.channels).intersection(set(Channel.PRIVATE)):
+            self.channel_status[channel] = ChannelStatus.UNSUBSCRIBED
 
     def _check_attributes(self):
         for attr, _type in [
@@ -194,6 +243,13 @@ class BcexClient(object):
                     f"{attr} should be a {_type} not {type(getattr(self, attr))}"
                 )
 
+    @property
+    def authenticated(self):
+        return (
+            self.channel_status.get(Channel.AUTH, ChannelStatus.UNSUBSCRIBED)
+            == ChannelStatus.SUBSCRIBED
+        )
+
     def _subscribe_channels(self):
         # Public channel subscriptions - symbol specific
         self._public_subscription()
@@ -207,26 +263,68 @@ class BcexClient(object):
             )
 
     def _public_subscription(self):
-        for channel in set(self.channels).intersection(set(Channel.PUBLIC)):
-            for i in self.symbols:
-                s = {"action": "subscribe", "channel": channel, "symbol": i}
-                kwargs = self.channel_kwargs.get(channel)
+        channels = set(self.channels).intersection(set(Channel.PUBLIC))
+        subscriptions_to_check = self._send_subscriptions_to_ws(channels)
+        self._wait_for_confirmation(subscriptions_to_check)
+
+    def _send_subscriptions_to_ws(self, channels):
+        subscriptions_to_check = []
+        for channel in channels:
+            kwargs = self.channel_kwargs.get(channel)
+            if Channel.is_symbol_specific(channel):
+                for symbol in self.symbols:
+                    subscription = {
+                        "action": Action.SUBSCRIBE,
+                        "channel": channel,
+                        "symbol": symbol,
+                    }
+                    if kwargs:
+                        subscription.update(kwargs)
+                    self.channel_status[channel][
+                        symbol
+                    ] = ChannelStatus.WAITING_CONFIRMATION
+                    logging.info(subscription)
+                    self.ws.send(json.dumps(subscription))
+                    subscriptions_to_check.append((channel, symbol))
+            else:
+                subscription = {"action": Action.SUBSCRIBE, "channel": channel}
                 if kwargs:
-                    s.update(kwargs)
+                    subscription.update(kwargs)
+                logging.info(subscription)
+                self.channel_status[channel] = ChannelStatus.WAITING_CONFIRMATION
+                self.ws.send(json.dumps(subscription))
+                subscriptions_to_check.append((channel, None))
+        return subscriptions_to_check
 
-                logging.info(s)
-                self.ws.send(json.dumps(s))
+    def _wait_for_confirmation(self, subscriptions_to_check):
+        all_answered = False
+        conn_timeout = 5
+        while not all_answered and conn_timeout:
+            time.sleep(1)
+            conn_timeout -= 1
+            all_answered = True
+            for channel, symbol in subscriptions_to_check:
+                if not self.check_channel_status(
+                    ChannelStatus.WAITING_CONFIRMATION, channel, symbol
+                ):
+                    all_answered = False
+                    break
 
-        # TODO: wait for public subscriptions to be complete i.e. wait for data from each
-        # chosen channel to have retrieved some data
+        if not all_answered:
+            logging.warning("Could not subscribe to all channels")
+
+    def check_channel_status(self, status, channel, symbol=None):
+        if symbol is None:
+            return self.channel_status[channel] == status
+        else:
+            return self.channel_status[channel][symbol] == status
 
     def _private_subscription(self):
         self._authenticate()
-        for channel in set(self.channels).intersection(set(Channel.PRIVATE)):
-            if channel == Channel.AUTH:
-                # already subscribed
-                continue
-            self.ws.send(json.dumps({"action": Action.SUBSCRIBE, "channel": channel}))
+        channels = set(self.channels).intersection(set(Channel.PRIVATE))
+        channels = channels - {Channel.AUTH}  # already subscribed
+        subscriptions_to_check = self._send_subscriptions_to_ws(channels)
+        self._wait_for_confirmation(subscriptions_to_check)
 
     def connect(self):
         """Connects to the websocket and runs it
@@ -350,7 +448,6 @@ class BcexClient(object):
             logging.warning(f"Received with delay message with seqnum {seqnum}")
         else:
             self._seqnum = seqnum
-            logging.debug(f"Received message with expected seqnum {seqnum}")
 
     def _on_message_unsupported(self, message):
         if message["channel"] in Channel.ALL:
@@ -364,7 +461,7 @@ class BcexClient(object):
 
     def _on_symbols_updates(self, msg):
         if msg["event"] == Event.SUBSCRIBED:
-            logging.info(f"Successfully subscribed to symbols")
+            self._on_subscribed_updates(msg)
         elif msg["event"] == Event.SNAPSHOT:
             # has only one symbol per message unlike the documentation
             symbol = msg["symbol"]
@@ -379,12 +476,12 @@ class BcexClient(object):
     def _on_market_trade_updates(self, msg):
         """Handle market trades by appending to symbol trade history"""
         if msg["event"] == Event.SUBSCRIBED:
-            logging.info(f"Successfully subscribed to trades for {msg['symbol']}")
+            self._on_subscribed_updates(msg)
         elif msg["event"] == Event.UPDATED:
             symbol = msg["symbol"]
             trades = self.market_trades[symbol]
             trade = Trade.parse_from_msg(msg)
-            self.market_trades[symbol] = _update_max_list(
+            self.market_trades[symbol] = update_max_list(
                 trades, trade, self.MAX_TRADES_LEN
             )
         else:
@@ -393,21 +490,49 @@ class BcexClient(object):
     def _on_price_updates(self, msg):
         """ Store latest candle update and truncate list to length MAX_CANDLES_LEN"""
         if msg["event"] == Event.SUBSCRIBED:
-            key = msg["symbol"]
-            logging.info(f"{key} candles subscribed to.")
-            logging.info(f"{msg['symbol']} candles subscribed to.")
+            self._on_subscribed_updates(msg)
         elif msg["event"] == Event.UPDATED:
             key = msg["symbol"]
             # TODO: what else would be inside the msg?
             if "price" in msg:
                 candles = self.candles[key]
-                self.candles[key] = _update_max_list(
+                self.candles[key] = update_max_list(
                     candles, msg["price"], self.MAX_CANDLES_LEN
                 )
         elif msg["event"] == Event.REJECTED:
             logging.warning(f"Price update rejected. Reason : {msg['text']}")
         else:
             self._on_unsupported_event_message(msg, Channel.PRICES)
+
+    def _on_subscribed_updates(self, msg):
+        """When receiving an message about a confirmed subscription
+
+        Updates the internal attributes to keep track of what channels are subscribed to
+        """
+        channel = msg["channel"]
+        log = f"Successfully subscribed to channel {channel}"
+        if "symbol" in msg:
+            symbol = msg["symbol"]
+            log = f"[{symbol}] " + log
+            self.channel_status[channel][symbol] = ChannelStatus.SUBSCRIBED
+        else:
+            self.channel_status[channel] = ChannelStatus.SUBSCRIBED
+        logging.info(log)
+
+    def _on_rejected_subscription_updates(self, msg):
+        """When receiving an message about a rejected subscription
+
+        Updates the internal attributes to keep track of what channels are subscribed to
+        """
+        channel = msg["channel"]
+        log = f"Subscription to channel {channel} rejected. Reason : {msg.get('text', 'Not Provided')}"
+        if "symbol" in msg:
+            symbol = msg["symbol"]
+            log = f"[{symbol}] " + log
+            self.channel_status[channel][symbol] = ChannelStatus.REJECTED
+        else:
+            self.channel_status[channel] = ChannelStatus.REJECTED
+        logging.warning(log)
 
     def _on_unsupported_event_message(self, msg, channel):
         if msg["event"] in Event.ALL:
@@ -421,9 +546,12 @@ class BcexClient(object):
 
     def _on_ticker_updates(self, msg):
         if msg["event"] == Event.SUBSCRIBED:
-            logging.info(f"Subscribed to the {msg['channel']} channel")
-        elif "last_trade_price" in msg:
-            self.tickers[msg["symbol"]] = msg["last_trade_price"]
+            self._on_subscribed_updates(msg)
+        elif msg["event"] in [Event.SNAPSHOT, Event.UPDATED]:
+            # last_trade_price not always present
+            for k in ["last_trade_price", "price_24h", "volume_24h"]:
+                if k in msg:
+                    self.tickers[msg["symbol"]].update({k: msg[k]})
         else:
             self._on_unsupported_event_message(msg, Channel.TICKER)
 
@@ -434,9 +562,7 @@ class BcexClient(object):
             # We should clear existing levels
             self.l2_book[symbol] = {Book.BID: sd(), Book.ASK: sd()}
         if msg["event"] == Event.SUBSCRIBED:
-            logging.info(
-                f"Subscribed to the {msg['channel']} channel for symbol {symbol}"
-            )
+            self._on_subscribed_updates(msg)
         elif msg["event"] in [Event.SNAPSHOT, Event.UPDATED]:
             for book in [Book.BID, Book.ASK]:
                 updates = msg[book]
@@ -462,7 +588,7 @@ class BcexClient(object):
 
     def _on_heartbeat_updates(self, msg):
         if msg["event"] == Event.SUBSCRIBED:
-            logging.info(f"Subscribed to the {msg['channel']} channel")
+            self._on_subscribed_updates(msg)
         elif msg["event"] == Event.UPDATED:
             self._last_heartbeat = valid_datetime(msg["timestamp"])
             logging.debug(f"Updated last heartbeat to {self._last_heartbeat}")
@@ -471,7 +597,7 @@ class BcexClient(object):
 
     def _on_auth_updates(self, msg):
         if msg["event"] == Event.SUBSCRIBED:
-            self.authenticated = True
+            self._on_subscribed_updates(msg)
         elif msg["event"] == Event.REJECTED:
             if self.authenticated:
                 logging.warning("Trying To Authenticate while already authenticated")
@@ -482,7 +608,7 @@ class BcexClient(object):
 
     def _on_balance_updates(self, msg):
         if msg["event"] == Event.SUBSCRIBED:
-            logging.info(f"Subscribed to the {msg['channel']} channel")
+            self._on_subscribed_updates(msg)
         elif msg["event"] == Event.SNAPSHOT:
             self.balances = parse_balance(msg["balances"])
         else:
@@ -497,7 +623,7 @@ class BcexClient(object):
         elif msg["event"] == Event.REJECTED:
             self._on_order_rejection(msg)
         elif msg["event"] == Event.SUBSCRIBED:
-            logging.info(f"Subscribed to the {msg['channel']} channel")
+            self._on_subscribed_updates(msg)
         else:
             self._on_unsupported_event_message(msg, Channel.TRADING)
 
@@ -516,8 +642,11 @@ class BcexClient(object):
             self._on_order_update(mo)
 
     def _on_order_rejection(self, msg):
-        # TODO: handle outgoing orders - those without orderID yet
-        logging.info(f"Removing {msg['orderID']} from open orders")
+        if self.channel_status[Channel.TRADING] == ChannelStatus.SUBSCRIBED:
+            # TODO: handle outgoing orders - those without orderID yet
+            logging.info(f"Removing {msg['orderID']} from open orders")
+        else:
+            self._on_rejected_subscription_updates(msg)
 
     def cancel_order(self, order_id):
         return self.send_order(Order(OrderType.CANCEL, order_id=order_id))

--- a/tests/websocket_client_test.py
+++ b/tests/websocket_client_test.py
@@ -15,3 +15,39 @@ class TestBcexClientPriceUpdates(object):
             "text": "No granularity set",
         }
         client._on_price_updates(msg)
+
+    def test_on_ticker_updates(self):
+        client = BcexClient(Mock())
+
+        # snapshot event - with last_trade_price
+        msg_1 = {
+            "seqnum": 1,
+            "event": "snapshot",
+            "channel": "ticker",
+            "symbol": "BTC-USD",
+            "price_24h": 7500.0,
+            "volume_24h": 0.0141,
+            "last_trade_price": 7499.0,
+        }
+        client._on_ticker_updates(msg_1)
+        assert client.tickers["BTC-USD"]["price_24h"] == 7500.0
+        assert client.tickers["BTC-USD"]["volume_24h"] == 0.0141
+        assert (
+            client.tickers["BTC-USD"]["last_trade_price"] == 7499.0
+        )  # from previous update
+
+        # updated event - no last_trade_price
+        msg_2 = {
+            "seqnum": 24,
+            "event": "updated",
+            "channel": "ticker",
+            "symbol": "BTC-USD",
+            "price_24h": 7500.1,
+            "volume_24h": 0.0142,
+        }
+        client._on_ticker_updates(msg_2)
+        assert client.tickers["BTC-USD"]["price_24h"] == 7500.1
+        assert client.tickers["BTC-USD"]["volume_24h"] == 0.0142
+        assert (
+            client.tickers["BTC-USD"]["last_trade_price"] == 7499.0
+        )  # from previous update


### PR DESCRIPTION
 - introduce Attribute channel_status which keeps track of the subscriptions
 - use channel_status to wait until confirmation of the subscription
 - update on_tickers_update to consume price and volume in the last 24h too
 - set default environment to PROD
 - use channel_status to know whether the trading update is about channel
 subscription or order rejection
 - fix heartbeat being subscribed multiple times, once per symbol

TODO :
 - [x] update channel status when socket closes